### PR TITLE
CICD use cancelot builder

### DIFF
--- a/.cicd/apply-triggers.cloudbuild.yaml
+++ b/.cicd/apply-triggers.cloudbuild.yaml
@@ -1,8 +1,16 @@
 steps:
+  - name: gcr.io/$PROJECT_ID/cancelot
+    id: "Cancelot"
+    args:
+      - "--current_build_id"
+      - "$BUILD_ID"
+      - "--branch_name"
+      - "$BRANCH_NAME"
+      - "--same_trigger_only"
   - name: gcr.io/$PROJECT_ID/meta-triggers
     id: "Apply Cloud Build Trigger configs from repo"
     waitFor:
-      - "-"
+      - "Cancelot"
     args:
-      - .cicd
+      - ".cicd"
 tags: ["meta-triggers"]

--- a/.cicd/build-custom-builders.cloudbuild.yaml
+++ b/.cicd/build-custom-builders.cloudbuild.yaml
@@ -1,10 +1,18 @@
 steps:
+  - name: gcr.io/$PROJECT_ID/cancelot
+    id: "Cancelot"
+    args:
+      - "--current_build_id"
+      - "$BUILD_ID"
+      - "--branch_name"
+      - "$BRANCH_NAME"
+      - "--same_trigger_only"
   - name: gcr.io/$PROJECT_ID/meta-cloud-builder
     id: "Build: custom images asynchronously"
     waitFor:
       - "-"
     args:
-      - .cicd/builders/custom-builders.yaml
-      - --timeout=900
-      - --async
+      - ".cicd/builders/custom-builders.yaml"
+      - "--timeout=900"
+      - "--async"
 tags: ["cloud-builders"]

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For security purposes, I would suggest only running this trigger on pushes to `m
 
 > NB: this will perform a `gcloub beta builds triggers import --source=""` of Trigger configs that do not change.
 
-:rotating_light: Trigger `includedFiles` uses [Go Regex with additions](https://cloud.google.com/cloud-build/docs/running-builds/create-manage-triggers#build_trigger), whereas the regex used by meta-triggers is Grep -E Perl regex. Take care.
+🚨 Trigger `includedFiles` uses [Go Regex with additions](https://cloud.google.com/cloud-build/docs/running-builds/create-manage-triggers#build_trigger), whereas the regex used by meta-triggers is Grep -E Perl regex. Take care.
 
 ## Contributing
 


### PR DESCRIPTION
Use Cancelot to cancel any builds on branches from the same trigger. This might lead to half-applied Cloud Build jobs so ensure they are idempotent.

Closes #18 