### PR TITLE
cicd: use shellcheck to lint shell scripts

### DIFF
--- a/.cicd/lint.cloudbuild.yaml
+++ b/.cicd/lint.cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+  - name: gcr.io/$PROJECT_ID/cancelot
+    id: "Cancelot"
+    args:
+      - "--current_build_id"
+      - "$BUILD_ID"
+      - "--branch_name"
+      - "$BRANCH_NAME"
+      - "--same_trigger_only"
+  - name: gcr.io/$PROJECT_ID/shellcheck
+    id: "Shellcheck"
+    waitFor:
+      - "Cancelot"
+    args:
+      - "**/*.sh"
+tags: ["lint"]

--- a/.cicd/triggers/lint.trigger.yaml
+++ b/.cicd/triggers/lint.trigger.yaml
@@ -1,0 +1,8 @@
+name: lint-on-pr
+description: "Lint all code on PRs"
+github:
+  owner: jthegedus
+  name: meta-cloud-builders
+  pullRequest:
+    branch: .*
+filename: .cicd/lint.cloudbuild.yaml


### PR DESCRIPTION
This sets up the linting of all shell scripts on PR with a Trigger and Cloud Build job.

Should close #19 